### PR TITLE
Move to babel 4.3

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -10,8 +10,8 @@
 
 ### ES6
 
-- [x] 6to5-loader with minimal runtime dependency footprint
-- [x] Server-side `require("6to5/register");` ES6 polyfill
+- [x] babel-loader with minimal runtime dependency footprint
+- [x] Server-side `require("babel/register");` ES6 polyfill
 
 ### Flux & Data Fetching
 
@@ -47,4 +47,3 @@
 ### Internationalization
 
 - [ ] react-intl
-

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     ]
   },
   "dependencies": {
-    "6to5": "^3.3.4",
-    "6to5-runtime": "^3.3.4",
+    "babel": "^4.3.0",
+    "babel-runtime": "^4.3.0",
     "body-parser": "^1.6.4",
     "chroma-js": "^0.6.3",
     "compression": "^1.3.0",
@@ -70,12 +70,11 @@
     "when": "^3.6.3"
   },
   "devDependencies": {
-    "6to5-core": "^3.1.1",
-    "6to5-loader": "^3.0.0",
+    "babel-core": "^4.3.0",
+    "babel-loader": "^4.0.0",
     "eslint": "^0.13.0",
     "jest-cli": "^0.2.1",
     "json-loader": "^0.5.1",
-    "jsx-loader": "^0.12.0",
     "react-hot-loader": "^1.0.4",
     "react-tools": "^0.12.2",
     "supervisor": "^0.6.0",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 /* @flow weak */
 
 "use strict";
-require("6to5/register");
+require("babel/register");
 require('node-jsx').install({extension: '.js'});
 var express = require('express');
 var compression = require('compression');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ var config = {
   ],
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loaders: ['react-hot', '6to5-loader?experimental&optional=selfContained', 'jsx?harmony'] }
+      { test: /\.js$/, exclude: /node_modules/, loaders: ['react-hot', 'babel-loader?experimental&optional=selfContained'] }
     ]
   }
 };


### PR DESCRIPTION
No need for the jsx loader since babel now supports JSX out of the box.