### PR TITLE
Honor HOT_LOAD_PORT environment var

### DIFF
--- a/hotLoadServer.js
+++ b/hotLoadServer.js
@@ -11,7 +11,7 @@ var config = require('./webpack.config');
 var port = process.env.HOT_LOAD_PORT || 8888;
 
 new WebpackDevServer(webpack(config), {
-  contentBase: 'http://localhost:8888',
+  contentBase: 'http://localhost:' + port,
   publicPath: config.output.publicPath,
   noInfo: true,
   hot: true

--- a/server.js
+++ b/server.js
@@ -81,7 +81,8 @@ server.use(function (req, res, next) {
 
   // In development, the compiled javascript is served by a WebpackDevServer, which lets us 'hot load' scripts in for live editing.
   if (process.env.NODE_ENV === "development") {
-    res.write('<script src="http://localhost:8888/build/client.js" defer></script>');
+    var hotLoadPort = process.env.HOT_LOAD_PORT || 8888;
+    res.write('<script src="http://localhost:' + hotLoadPort + '/build/client.js" defer></script>');
   }
 
   // In production, we just serve the pre-compiled assets from the /build directory

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,20 +5,22 @@
 var webpack = require('webpack');
 var path = require('path');
 
+var port = process.env.HOT_LOAD_PORT || 8888;
+
 var config = {
   cache: true,
   resolve: {
     extensions: ['', '.js']
   },
   entry: [
-    'webpack-dev-server/client?http://localhost:8888',
+    'webpack-dev-server/client?http://localhost:' + port,
     'webpack/hot/dev-server',
     './client.js'
   ],
   output: {
     path: path.join(__dirname, '/build/'),
     filename: 'client.js',
-    publicPath: 'http://localhost:8888/build/'
+    publicPath: 'http://localhost:' + port + '/build/'
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin()


### PR DESCRIPTION
I have other services running on port 8888 and 8080, so I need to use alternate ports.

This PR allows one to do something like this instead:

```
$ ( export PORT=7778 HOT_LOAD_PORT=7779; npm run dev )
```

A separate issue is that you can't do this:

```
$ PORT=7778 HOT_LOAD_PORT=7779 npm run dev   # <-- doesn't work
[ ... ]
   warn  - error raised: Error: listen EADDRINUSE
[ ... ]
```

So somewhere else will need a patch in order to pass down PORT and HOT_LOAD_PORT to child processes as needed.
